### PR TITLE
Fix Notion date property naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Notionデータベースには以下のプロパティが必要です：
 | `Title` | タイトル | 記事タイトル |
 | `Slug` | リッチテキスト | URL用スラッグ |
 | `Published` | チェックボックス | 公開状態 |
-| `Publish Date` | 日付 | 公開日 |
+| `PublishedDate` | 日付 | 公開日 |
 | `Tags` | マルチセレクト | タグ |
 | `Category` | セレクト | カテゴリ |
 | `Status` | セレクト | ステータス |

--- a/tokechan-blog/app/blog/[slug]/page.tsx
+++ b/tokechan-blog/app/blog/[slug]/page.tsx
@@ -15,10 +15,10 @@ export async function generateStaticParams() {
 
 export default async function BlogPostPage(
   props: {
-      params: Promise<{ slug: string }>;
+      params: { slug: string };
     }
 ) {
-  const params = await props.params;
+  const { params } = props;
   const post = await getPostBySlug(params.slug);
 
   if (!post) {

--- a/tokechan-blog/lib/notion.ts
+++ b/tokechan-blog/lib/notion.ts
@@ -19,7 +19,7 @@ export async function getPosts() {
         },
         sorts: [
             {
-                property: "Publish Date",
+                property: "PublishedDate",
                 direction: "descending",
             },
         ],
@@ -36,7 +36,7 @@ export async function getPosts() {
             slug: properties.Slug?.rich_text?.[0]?.plain_text || '',
             category: properties.Category?.select?.name || null,
             tags: properties.Tags?.multi_select?.map((tag: any) => tag.name) ?? [],
-            publishedDate: properties['Publish Data']?.date?.start || null,
+            publishedDate: properties.PublishedDate?.date?.start || null,
             }
     })
 }

--- a/tokechan-blog/lib/notion.ts
+++ b/tokechan-blog/lib/notion.ts
@@ -24,21 +24,19 @@ export async function getPosts() {
             },
         ],
     })
-    console.log("🟣 Notionから取得したposts", response.results);
-
-
-    return response.results.map((page: any) => {
-        const properties =page.properties
-        
-        return {
-            id: page.id,
-            title: properties.Title?.title?.[0]?.plain_text || 'No Title',
-            slug: properties.Slug?.rich_text?.[0]?.plain_text || '',
-            category: properties.Category?.select?.name || null,
-            tags: properties.Tags?.multi_select?.map((tag: any) => tag.name) ?? [],
-            publishedDate: properties.PublishedDate?.date?.start || null,
-            }
-    })
+    return response.results
+        .filter((page): page is PageObjectResponse => 'properties' in page)
+        .map((page) => {
+            const properties = page.properties as PageProperties;
+            return {
+                id: page.id,
+                title: properties.Title?.title?.[0]?.plain_text || 'No Title',
+                slug: properties.Slug?.rich_text?.[0]?.plain_text || '',
+                category: properties.Category?.select?.name || null,
+                tags: properties.Tags?.multi_select?.map((tag: any) => tag.name) ?? [],
+                publishedDate: properties.PublishedDate?.date?.start || null,
+            };
+        });
 }
 
 
@@ -68,9 +66,6 @@ export async function getPostBySlug(slug: string) {
         const markdownObj = await n2m.toMarkdownString(mdBlocks);
         const html = await marked(markdownObj.parent);
         
-        console.log("Serverでのhtmlの型",typeof html)
-    
-
         return {
             id: page.id,
             title: properties.Title?.title?.[0]?.plain_text ?? 'No Title',
@@ -112,6 +107,3 @@ export async function getPostAllPosts() {
         };
     });
 }
-// lib/notion.ts の初期化直後に一時的に追加
-console.log("NOTION_TOKEN:", process.env.NOTION_TOKEN);
-console.log("NOTION_DATABASE_ID:", process.env.NOTION_DATABASE_ID);


### PR DESCRIPTION
## Summary
- fix property name mismatch in Notion helper
- adjust slug page params type
- document `PublishedDate` property
- remove unused `Footer.tsx`

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist` and `Geist Mono`)*

------
https://chatgpt.com/codex/tasks/task_e_6841088fb3c0833280015cbf4ecd9258