### PR TITLE
feat: enhance status property handling in getPostBySlug function

### DIFF
--- a/lib/notion.ts
+++ b/lib/notion.ts
@@ -95,6 +95,15 @@ export async function getPostBySlug(slug: string) {
     (properties as Record<string, any>)["Publish Date"] ??
     null;
 
+  // Statusプロパティの取得を試行（複数の型に対応）
+  const statusProperty = properties.Status as any;
+  let status = "";
+  if (statusProperty?.select?.name) {
+    status = statusProperty.select.name;
+  } else if (statusProperty?.status?.name) {
+    status = statusProperty.status.name;
+  }
+
   return {
     id: page.id,
     title: properties.Title?.title?.[0]?.plain_text ?? "No Title",
@@ -102,7 +111,7 @@ export async function getPostBySlug(slug: string) {
     category: properties.Category?.select?.name ?? null,
     tags: properties.Tags?.multi_select?.map((tag: any) => tag.name) ?? [],
     publishedDate: publishedDateProperty?.date?.start ?? null,
-    status: properties.Status?.select?.name ?? "",
+    status: status,
     content: html,
   };
 }

--- a/types/notion.ts
+++ b/types/notion.ts
@@ -1,33 +1,35 @@
 export type PageProperties = {
-    Title?: {
-      title?: {
-        plain_text: string;
-      }[];
-    };
-    Slug?: {
-      rich_text?: {
-        plain_text: string;
-      }[];
-    };
-    Category?: {
-      select?: {
-        name: string;
-      } | null;
-    };
-    Tags?: {
-      multi_select?: {
-        name: string;
-      }[];
-    };
-    Status?: {
-      select?: {
-        name: string;
-      } | null;
-    };
-    PublishedDate?: {
-      date?: {
-        start: string;
-      } | null;
-    };
+  Title?: {
+    title?: {
+      plain_text: string;
+    }[];
   };
-  
+  Slug?: {
+    rich_text?: {
+      plain_text: string;
+    }[];
+  };
+  Category?: {
+    select?: {
+      name: string;
+    } | null;
+  };
+  Tags?: {
+    multi_select?: {
+      name: string;
+    }[];
+  };
+  Status?: {
+    select?: {
+      name: string;
+    } | null;
+    status?: {
+      name: string;
+    } | null;
+  };
+  PublishedDate?: {
+    date?: {
+      start: string;
+    } | null;
+  };
+};


### PR DESCRIPTION
- Updated the getPostBySlug function to support multiple status property types, allowing for better compatibility with Notion's API.
- Modified the PageProperties type to include an additional status field, improving type safety and clarity.